### PR TITLE
Gate mutation of `partsToNotify` based on `index` compared to `length`

### DIFF
--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 // import App from './async';
-import App from './playground';
+// import App from './playground';
 // import App from './simple';
-// import App from './todos';
+import App from './todos';
 
 document.body.style.backgroundColor = '#1d1d1d';
 document.body.style.color = '#d5d5d5';

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 // import App from './async';
-// import App from './playground';
+import App from './playground';
 // import App from './simple';
-import App from './todos';
+// import App from './todos';
 
 document.body.style.backgroundColor = '#1d1d1d';
 document.body.style.color = '#d5d5d5';

--- a/src/enhancer.ts
+++ b/src/enhancer.ts
@@ -77,10 +77,12 @@ export function createEnhancer<
       ) {
         const index = partsToNotify.indexOf(part.id);
 
-        partsToNotify.push(part.id);
+        if (index === -1 || index < partsToNotify.length - 1) {
+          if (index !== -1) {
+            partsToNotify.splice(index, 1);
+          }
 
-        if (index !== -1) {
-          partsToNotify.splice(index, 1);
+          partsToNotify.push(part.id);
         }
 
         for (let index = 0; index < part.d.length; ++index) {

--- a/src/enhancer.ts
+++ b/src/enhancer.ts
@@ -77,11 +77,10 @@ export function createEnhancer<
       ) {
         const index = partsToNotify.indexOf(part.id);
 
-        if (index === -1 || index < partsToNotify.length - 1) {
-          if (index !== -1) {
-            partsToNotify.splice(index, 1);
-          }
-
+        if (index === -1) {
+          partsToNotify.push(part.id);
+        } else if (index < partsToNotify.length - 1) {
+          partsToNotify.splice(index, 1);
           partsToNotify.push(part.id);
         }
 


### PR DESCRIPTION
## Reason for change

`addPartsToNotify` will order the Part IDs to ensure that dependencies are updated before their dependents. If it finds a match for the Part to add, it will splice out that Part ID before adding it (reordering it to the end), otherwise it will just add it to the end.

## Change

In scenarios where there are already Parts in the array, and the Part to be notified is the last entry, a `.splice()` + `.push()` operation is performed needlessly, as we are removing and adding the same Part ID at the same location. This change adds a gate to ensure that these operations actually need to occur.