### PR TITLE
Include `toString()` on stateful part updater

### DIFF
--- a/__tests__/part.ts
+++ b/__tests__/part.ts
@@ -30,6 +30,24 @@ describe('part', () => {
 
       expect(store.getState(primitivePart)).toBe('next value');
     });
+
+    it('should have a stateful updater', () => {
+      const primitivePart = part('primitive', 'value');
+      const store = createStore({ parts: [primitivePart] as const });
+
+      const custom = primitivePart.update(
+        'NORMALIZE_PRIMITIVE',
+        (value: string | number | boolean) => String(value)
+      );
+
+      store.dispatch(custom(false));
+      expect(store.getState(primitivePart)).toBe('false');
+
+      store.dispatch(custom(123));
+      expect(store.getState(primitivePart)).toBe('123');
+
+      expect(custom.toString()).toBe('primitive/NORMALIZE_PRIMITIVE');
+    });
   });
 
   describe('Composed', () => {
@@ -115,6 +133,25 @@ describe('part', () => {
       expect(store.getState(cPart)).toEqual({ b: { a: 'next value' } });
       expect(store.getState(bPart)).toEqual({ a: 'next value' });
       expect(store.getState(aPart)).toEqual('next value');
+    });
+
+    it('should have a stateful updater', () => {
+      const primitivePart = part('primitive', 'value');
+      const composedPart = part('composed', [primitivePart]);
+      const store = createStore({ parts: [composedPart] as const });
+
+      const custom = composedPart.update(
+        'NORMALIZE_PRIMITIVE',
+        (value: string | number | boolean) => ({ primitive: String(value) })
+      );
+
+      store.dispatch(custom(false));
+      expect(store.getState(composedPart)).toEqual({ primitive: 'false' });
+
+      store.dispatch(custom(123));
+      expect(store.getState(composedPart)).toEqual({ primitive: '123' });
+
+      expect(custom.toString()).toBe('composed/NORMALIZE_PRIMITIVE');
     });
   });
 

--- a/src/part.ts
+++ b/src/part.ts
@@ -63,6 +63,7 @@ import type {
   SelectPartArgs,
   Set,
   StatefulPartUpdater,
+  StatefulUpdatePart,
   Tuple,
   UnboundProxyPart,
   UnboundProxyPartConfig,
@@ -557,10 +558,13 @@ export function createPartUpdater<Part extends AnyStatefulPart>(part: Part) {
       });
     }
 
-    // @ts-expect-error - `set` types don't perfectly align, but we know them.
-    return createUpdatePart<typeof set>({
-      set,
-    });
+    // @ts-expect-error - `set` cannot determine the tuple from the rest parameters, but it works externally.
+    const updatePart = createUpdatePart({ set });
+
+    updatePart.toString = () => type;
+
+    // @ts-expect-error - `set` cannot determine the tuple from the rest parameters, but it works externally.
+    return updatePart as StatefulUpdatePart<typeof set>;
   } as StatefulPartUpdater<Part['i']>;
 }
 

--- a/src/part.ts
+++ b/src/part.ts
@@ -526,7 +526,7 @@ export function createUpdatePart<Updater extends AnyUpdater>(
 }
 
 export function createPartUpdater<Part extends AnyStatefulPart>(part: Part) {
-  return function partAction<GetValue extends AnyGetValue<Part['i']>>(
+  return function partUpdater<GetValue extends AnyGetValue<Part['i']>>(
     baseType: string,
     getValue: GetValue = identity as GetValue
   ) {

--- a/src/types/part.ts
+++ b/src/types/part.ts
@@ -97,7 +97,7 @@ export interface StatefulPartUpdater<State> {
    * Creates a dedicated action creator for updating the value in state
    * for this part. Allows for declarative action types.
    */
-  (type: string): UpdatePart<GetValueUpdater<State, [State]>>;
+  (type: string): StatefulUpdatePart<GetValueUpdater<State, [State]>>;
   /**
    * Creates a dedicated action creator for updating the value in state
    * for this part. Allows for declarative action types, as well as custom
@@ -106,7 +106,7 @@ export interface StatefulPartUpdater<State> {
   <GetValue extends AnyGetValue<State>>(
     type: string,
     getValue: GetValue
-  ): UpdatePart<
+  ): StatefulUpdatePart<
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - The tuple is not inferrable here, but passes through to the consumer.
     GetValueUpdater<State, Parameters<GetValue>>
@@ -330,6 +330,16 @@ export interface UpdatePart<Updater extends AnyUpdater> extends BasePart {
    * The update method used to [s]et 1-n values in state.
    */
   s: Updater;
+}
+
+export interface StatefulUpdatePart<Updater extends AnyUpdater>
+  extends UpdatePart<Updater> {
+  /**
+   * Returns the action type used whenever the Part updates its value
+   * in state. Can be useful as a key for action handlers on non-Part
+   * reducers, or in third-party tools like `redux-saga`'s `take`.
+   */
+  toString(): string;
 }
 
 export type AnyPart =


### PR DESCRIPTION
## Reason for change

Stateful Parts have a `toString()` method which allow for identifying the action type returned by their action creator. This can be helpful when used with third-party libraries such as `redux-saga`. However, the stateful updaters returned by `part.update()` do not have this same method, even though they are also action creators.

## Change

Create a new, specific type of `StatefulUpdatePart`, which is an `UpdatePart` that has the `toString()` applied. This creates parity with Stateful Parts, at least in terms of the specific aforementioned use.